### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aomarai/asdana/security/code-scanning/1](https://github.com/aomarai/asdana/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify `contents: read`, which is sufficient for the workflow's operations (e.g., checking out code and running Pylint). This change ensures that the workflow does not inadvertently gain unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Added root-level permissions block to limit workflow access to read-only for repository contents